### PR TITLE
Update self-link in spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -5,7 +5,7 @@ Level: 1
 Indent: 2
 Status: CG-DRAFT
 Group: WICG
-URL: https://wicg.github.io/dbsc/
+URL: https://w3c.github.io/webappsec-dbsc/
 Editor: Kristian Monsen 76841, Google, kristianm@google.com
 Editor: Daniel Rubery, Google, drubery@google.com
 Abstract: The Device Bound Sessions Credentials (DBSC) aims to prevent hijacking via cookie theft by building a protocol and infrastructure that allows a user agent to assert possession of a securely-stored private key. DBSC is a Web API and a protocol between user agents and servers to achieve this binding.


### PR DESCRIPTION
Now that the feature is adopted by WebAppSec, the self link is broken.