### PR TITLE
Have cookie expiry changes reflected in UI

### DIFF
--- a/server.js
+++ b/server.js
@@ -274,11 +274,12 @@ fastify.post("/internal/StartSession", function (request, reply) {
 
   // Set all cookies for the session.
   sessionInfo.cookies.forEach(cookie => {
+    cookie.expires = new Date(Date.now() + cookie.maxAgeInSec * 1000);
     reply.setCookie(cookie.name, to_json(cookie.value), {
       domain: cookie.domain,
       path: cookie.path,
       maxAge: cookie.maxAgeInSec,
-      expires: new Date(Date.now() + cookie.maxAgeInSec * 1000),
+      expires: cookie.expires,
       secure: cookie.secure,
       sameSite: true,
     });
@@ -332,11 +333,12 @@ fastify.post("/internal/RefreshSession", function (request, reply) {
 
   // Refresh all cookies for the session.
   g_sessions[session_id].cookies.forEach(cookie => {
+    cookie.expires = new Date(Date.now() + cookie.maxAgeInSec * 1000);
     reply.setCookie(cookie.name, to_json(cookie.value), {
       domain: cookie.domain,
       path: cookie.path,
       maxAge: cookie.maxAgeInSec,
-      expires: new Date(Date.now() + cookie.maxAgeInSec * 1000),
+      expires: cookie.expires,
       secure: cookie.secure,
       sameSite: true,
     });

--- a/server.js
+++ b/server.js
@@ -45,8 +45,8 @@ let g_session_registration_timeout_sec = 60;
 let g_pending_sessions = {};
 let g_session_id = 1;
 
-handlebars.registerHelper('isExpired', function (expires) {
-  return expires < Date.now();
+handlebars.registerHelper('hasCookieEverRefreshed', function (expires, expiresAtStartSession) {
+  return expires > expiresAtStartSession;
 })
 
 setInterval(() => {
@@ -125,7 +125,7 @@ class CookieInfo {
     this.path = "/";
     this.secure = true;
     this.sameSite = "Strict";
-    this.expires = new Date(Date.now() + this.maxAgeInSec * 1000);
+    // expires and expiresAtStartSession are unset until StartSession.
   }
 
   get attributes() {
@@ -275,6 +275,7 @@ fastify.post("/internal/StartSession", function (request, reply) {
   // Set all cookies for the session.
   sessionInfo.cookies.forEach(cookie => {
     cookie.expires = new Date(Date.now() + cookie.maxAgeInSec * 1000);
+    cookie.expiresAtStartSession = cookie.expires;
     reply.setCookie(cookie.name, to_json(cookie.value), {
       domain: cookie.domain,
       path: cookie.path,

--- a/src/pages/index.hbs
+++ b/src/pages/index.hbs
@@ -60,7 +60,7 @@
                   <th>CookieName</th>
                   <th>CookieValue</th>
                   <th>CookieExpireTime</th>
-                  <th>CookieExpired</th>
+                  <th>CookieEverRefreshed</th>
                   <th>DeleteSession</th>
                 </tr>
                 {{#each sessions as |session|}}
@@ -69,7 +69,7 @@
                     <td>{{session.cookies.[0].name}}</td>
                     <td>{{session.cookies.[0].value}}</td>
                     <td>{{session.cookies.[0].expires}}</td>
-                    <td>{{isExpired session.cookies.[0].expires}}</td>
+                    <td>{{hasCookieEverRefreshed session.cookies.[0].expires session.cookies.[0].expiresAtStartSession}}</td>
                     <td><button
                         type="submit"
                         formmethod="post"


### PR DESCRIPTION
This PR:
1. Fixes the CookieExpireTime values so they display the latest values on refresh, and
2. Replaces the CookieExpired column with a new column CookieEverRefreshed.

When the actual browser cookie has its expires field updated, that needs to be updated within the cookies in g_sessions as well for the changes to be reflected in the UI (for the columns CookieExpireTime and CookieExpired).

Once that's true, that makes the CookieExpired column not very useful, because it will always say "false" since a page reload will trigger a refresh and unexpire any expired cookies. So, that column is replaced with a new column displaying whether a cookie's expiry has ever increased (CookieEverRefreshed). It starts out as false, and it gets set to true once a refresh increases the cookie's expiry.