### PR TITLE
Let deploy.sh use multiple remotes

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,16 +1,39 @@
 set -e
 
 # Usage:
-#   ./deploy.sh <branch to deploy>
-# The branch is optional and defaults to origin/glitch.
-#
-# This requires you to have an upstream called "glitch" which points to
-# the URL fetched from the Glitch UI. You can create one with:
-#   git remote add glitch $GLITCH_URL
+#   ./deploy.sh <remote name> <branch name>
+# Pushes the current state of <branch name> to the Glitch remote <remote
+# name>. <branch name> defaults to "origin/glitch", and <remote name> to
+# "glitch".
 
-git new-branch --upstream glitch/main deploy_glitch
-git checkout ${1:-origin/glitch} -- .
+# One time setup:
+
+# This requires you to have setup an upstream which points to
+# the URL fetched from the Glitch UI. You can create one with:
+#   git remote add <remote name> $GLITCH_URL
+#   git pull <remote name>
+# It is recommended to have one upstream called "glitch" for the
+# prototype server, https://glitch.com/edit/#!/dbsc-prototype-server,
+# and one for a personal remix of that project you can use for staging.
+
+# Recommended Development process:
+
+# Create a new branch tracking the main repo:
+#   git new-branch --upstream origin/glitch <branch name>
+# Develop your code on that branch
+# Test with:
+#   ./deploy.sh <personal remix> <branch name>
+# When satisfied, push this branch and create a pull request:
+#   git push -u origin <branch name>
+# When the pull request is landed, deploy to the prototype server:
+#   ./deploy.sh
+
+BRANCH=${2:-origin/glitch}
+REMOTE=${1:-glitch}
+
+git new-branch --upstream $REMOTE/main deploy_glitch
+git checkout $BRANCH -- .
 git commit -a -m "Automated deployment"
-git push -u glitch deploy_glitch:main
-git checkout ${1:-origin/glitch}
+git push -u $REMOTE deploy_glitch:main
+git checkout $BRANCH
 git branch -D deploy_glitch

--- a/server.js
+++ b/server.js
@@ -29,7 +29,7 @@ const fastify = require("fastify")({
 require('dotenv').config();
 // Please set up server port and host, for example "127.0.0.1" for local testing.
 let g_listening_host = process.env.DBSC_HOST ? process.env.DBSC_HOST : "0.0.0.0";
-let g_listening_port = process.env.DBSC_PORT ? process.env.DBSC_PORT : 0;
+let g_listening_port = process.env.DBSC_PORT ? process.env.DBSC_PORT : 3000;
 
 let g_sessions = {};
 let g_default_cookie_age_sec = 10*60;


### PR DESCRIPTION
In order to streamline development, we want people to be able to use a remixed server for staging changes. Creating a remix currently requires modifying .env each time. This commit fixes that and updates deploy.sh to support a staging remote.