### PR TITLE
Update contribution file with WebAppSec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,9 @@
 # Device Bound Session Credentials
 
-This repository is being used for work in the W3C Device Bound Session Credentials, governed by the [W3C Community License
-Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To make substantive contributions,
-you must join the CG.
+This repository is being used for work in the W3C Device Bound Session
+Credentials, governed by the [W3C Community License Agreement
+(CLA)](http://www.w3.org/community/about/agreements/cla/). It is being developed
+in the WebAppSec WG. To make substantive contributions, you must join the WG.
 
 If you are not the sole contributor to a contribution (pull request), please identify all
 contributors in the pull request comment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Device Bound Session Credentials
 
-This repository is being used for work in the W3C Device Bound Session
-Credentials, governed by the [W3C Community License Agreement
-(CLA)](http://www.w3.org/community/about/agreements/cla/). It is being developed
-in the WebAppSec WG. To make substantive contributions, you must join the WG.
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy/) and
+[Software and Document License](https://www.w3.org/copyright/software-license/). To make substantive contributions to specifications, you must either participate
+in the relevant W3C Working Group or make a non-member patent licensing commitment.
 
 If you are not the sole contributor to a contribution (pull request), please identify all
 contributors in the pull request comment.


### PR DESCRIPTION
DBSC has been adopted by WebAppSec so remove the reference to the CG in CONTRIBUTING.md.