### PR TITLE
Update JWT type in explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ The JWT proof is signed with the newly created private key, and needs to contain
 // Header
 {
   "alg": "Signature Algorithm",
-  "typ": "JWT",
+  "typ": "dbsc+jwt",
 }
 // Payload
 {


### PR DESCRIPTION
The spec says "dbsc+jwt", so we should say that in the explainer too.