### PR TITLE
Clarify JWT format

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,7 @@ The JWT proof is signed with the newly created private key, and needs to contain
   "aud": "URL of this request",
   "jti": "challenge_value",
   "iat": "timestamp", // Number, represent number of seconds since Jan 1, 1970
-  "key": {
-    "kty": "key type",
-    "<kty-specific parameters>": "<value>",
-  },
+  "key": "public key JWK",
   "authorization": "<authorization_value>", // optional, only if set in registration header
 }
 ```
@@ -307,8 +304,10 @@ Sec-Session-Response: JWT proof
 The JWT proof contains:
 ```json
 {
-  "jti": "challenge_value",
   "aud": "the URL to which the Sec-Session-Response will be sent",
+  "jti": "challenge_value",
+  "iat": "timestamp",
+  "key": "jwk of session public key",
   "sub": "the session ID corresponding to the binding key",
 }
 ```

--- a/spec.bs
+++ b/spec.bs
@@ -662,7 +662,7 @@ The payload of [=DBSC proof=] MUST contain at least the following claims:
   :: a [=string=], this claim identifies the time at which the JWT was
     issued.  This claim can be used to determine the age of the JWT.  Its
     value MUST be a number containing a NumericDate value.
-  : <dfn>jwk</dfn>
+  : <dfn>key</dfn>
   :: a [=string=] defining a JWK as specified in [rfc7517].
 </dl>
 
@@ -674,6 +674,13 @@ In addition the following claims MUST be present if present in
     [:Sec-Session-Registration:], if set there. Note that this string is
     OPTIONAL to include in the header, but if it is present it is
     MANDATORY for clients to add the claim in the [=DBSC proof=].
+</dl>
+
+If the DBSC proof is for a refresh request, the following claim MUST be
+present:
+<dl dfn-for="DBSC proof">
+  : <dfn>sub</dfn>
+  :: the [=device bound session/session identifier=], a [=string=].
 </dl>
 
 <div class="example" id="dbsc-proof-example">
@@ -690,7 +697,7 @@ In addition the following claims MUST be present if present in
     "aud": "https://example.com/reg",
     "jti": "cv",
     "iat": "1725579055",
-    "jwk": {
+    "key": {
       "kty": "EC",
       "crv": "P-256",
       "x": "6_GB2voQ0qroMh6OlDFCFS_SJriQi1PTvvBOhGZ3bHI",


### PR DESCRIPTION
The spec and explainer do not agree on what keys are in the JWT. This will align them.