### PR TITLE
Include some server-side recommendations in the spec

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -161,6 +161,36 @@ This is mitigated by requiring user opt-in through the Storage Access
 API. The victim site must request access to its first-party state in
 order for DBSC to apply within the cross-site context.
 
+# Alternatives considered # {#alternatives}
+## WebAuthn and silent mediation ## {#alternatives-webauthn}
+
+# Server considerations # {#server-considerations}
+
+In order to use DBSC, site owners need to establish two new endpoints:
+the regsitration endpoint and the refresh endpoint.
+
+The registration endpoint is contacted asynchronously after receiving
+the Sec-Session-Registration header. This endpoint should:
+- Serve the session config, including a new session id.
+- Persist and associate the request's public key with the session id.
+
+The refresh endpoint is much more sensitive. This endpoint is contacted every
+time a request is made with an expired bound cookie, and its response blocks
+the original request. Failure to respond or restore the bound cookie may
+cause browser agents to begin denial-of-service prevention mechanisms, or even
+terminate the session. Both could lead to future requests without bound
+cookies. The expected behavior of this endpoint is:
+- Look up the public key and recent challenges for the session by id.
+- Validate the Sec-Session-Response header has signed a recent challenge with
+  the correct key. Note that due to network latency and race conditions, it's
+  possible to receive a signature for an old challenge after issuing a new
+  challenge.
+- Issue new bound cookies.
+- Serve the current session config.
+
+# Alternatives considered # {#alternatives}
+## WebAuthn and silent mediation ## {#alternatives-webauthn}
+
 # Framework # {#framework}
 This document uses ABNF grammar to specify syntax, as defined in [[!RFC5234]]
 and updated in [[!RFC7405]], along with the `#rule` extension defined in


### PR DESCRIPTION
The refresh endpoint is very sensitive to availability and latency issues. Site owners should be aware of that when adopting DBSC.