### PR TITLE
Update spec.bs to origin with scheme

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -700,7 +700,7 @@ At the root of the JSON object the following keys can exist:
       // Origin-scoped by default (i.e. https://example.com)
       // Specifies to include https://*.example.com except excluded subdomains.
       // This can only be true if the origin's host is the root eTLD+1.
-      "origin": "example.com",
+      "origin": "https://example.com",
       "include_site": true,
       "continue": false,
       "defer_requests": true, // optional and true by default


### PR DESCRIPTION
When the `origin` field does not contain the scheme, DBSC returns `InvalidScopeOrigin` from `RegistrationResult`.

If the scheme is not required, then this PR should be closed and the implementation itself be updated.