### PR TITLE
Do not defer requests without credentials

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -319,6 +319,7 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   domain=], this algorithm describes how to identify which session, if
   any, should block |request| from proceeding.
 
+  1. If |request|'s [=request/credentials mode=] is "omit", return null.
   1. Let |site| be the [=host/registrable domain=] of the |request| [=URL=].
   1. Let |domain sessions| be [=sessions by registrable domain=][|site|] as [=/session by id=]
   1. [=list/For each=] |session| of |domain sessions|


### PR DESCRIPTION
We hint at this in #algo-identify-missing-session-credential, but the cookie check only checks things like third party cookie settings, not the credentials mode.