### PR TITLE
Update session selection mechanism

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -26,6 +26,7 @@ spec:html; type:element; text:link
 spec:fetch; type:dfn; text:name
 spec:fetch; type:dfn; text:value
 spec:infra; type:dfn; text:list
+spec:infra; type:dfn; text:tuple
 spec:permissions; type:dfn; text:feature
 </pre>
 
@@ -329,13 +330,18 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
        refresh endpoint has recently been unreachable (denial of service
        risk for the site).
     1. If |session|'s [=expiration timestamp=] is before the present, [=iteration/continue=].
+    1. Let |id| be |session|'s [=device bound session/session identifier=].
+    1. If the [=tuple=] (|site|, |id|) is in |request|'s
+      [=deferred device bound session ids=], [=iteration/continue=].
     1. Run the steps in [[#algo-url-in-scope]] on the |request|'s URL
-       and |session|'s scope.
-    1. If the result does not indicate the request is in scope, skip |session|
-       and [=iteration/continue=].
-    1. Run the steps of [[#algo-identify-missing-session-credential]] on
-       |request| and |session|'s [=session credentials=]. If the result is
-       true, return |session|.
+       and |session|'s scope. 
+    1. If the result does not indicate the request is in scope,
+      [=iteration/continue=].
+    1. If the result of running [[#algo-identify-missing-session-credential]]
+      on |request| and |session|'s [=session credentials=] is false,
+      [=iteration/continue=].
+    1. Add (|site|, |id|) to |request|'s [=deferred device bound session ids=].
+    1. Return |session|.
   1. If no session has been identified, return null.
 </div>
 
@@ -396,12 +402,10 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   This algorithm describes how to <dfn export dfn-for="algorithms">send
   a request</dfn> for a device bound session registration or refresh. It
   takes as input an |originating request|, |key pair|, |destination|,
-  and optional |session id|, |challenge|, and |authorization|. It
-  returns one of "continue" or "restart", indicating if |originating
-  request| should be restarted or continued.
+  and optional |session id|, |challenge|, and |authorization|.
 
   1. If |originating request|'s [=request/URL=] is not [=/same site=] with
-     |destination|, return "continue".
+     |destination|, return.
   1. Let |signed challenge| be null. If |challenge| is non-null, sign it
      with |key pair| and store the result in |signed challenge|.
   1. Create a |request| for use in <a
@@ -419,20 +423,18 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   1. Let |response| be the result of running <a
      href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">HTTP-network-or-cache
      fetch</a> for |request|.
-  1. If the result is a redirect, and the destination does not have the
-     HTTPS scheme and is not localhost, cancel the request and return "continue".
   1. If |response| is a [=network error=], or |response|'s
-     [=response/status=] is 407, return "continue".
+     [=response/status=] is 407, return.
   1. If |response|'s [=response/status=] is a redirect status, and the
      destination does not have the HTTPS scheme and is not localhost, cancel the
-     request.
+     request and return.
   1. If |response|'s [=response/status=] is 401 and has a
      "Sec-Session-Challenge" header, start this algorithm over with a new
      challenge value.
   1. If |response|'s [=response/status=] is below 500, then terminate the
-     session and return "continue".
+     session and return.
   1. If |response|'s [=response/status=] is at least 500, then
-     return "continue". Browsers may choose to trigger a backoff mechanism on
+     return. Browsers may choose to trigger a backoff mechanism on
      subsequent refresh requests on this session, to limit the harm of a
      temporary outage on the refresh endpoint.
   1. Parse |response|'s [=response/body=] according to
@@ -442,9 +444,9 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
     1. Run the steps of [[#algo-identify-session]] on |destination| and |session
        identifier|.
     1. If the result is non-null, delete the returned session.
-    1. Return "continue" from this algorithm.
-  1. Otherwise, perform the following validations, returning "continue" if any fail:
-    1. |session identifier| must be nonempty.
+    1. Return from this algorithm.
+  1. Otherwise, perform the following validations, returning if any fail:
+    1. |session identifier| must be non-empty.
     1. The value of the key "refresh_url" must be non-empty.
     1. Let |origin| be the value of the key "scope.origin", if present, or the
        origin of |destination| if not.
@@ -461,10 +463,10 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
        [=url/host=] replaced with |destination site|, and the [=url/path=]
        replaced with "/.well-known/device-bound-sessions".
     1. Let |well known response| be the result of fetching |well known URL|.
-    1. If |well known response|'s [=response/status=] is not 200, return "continue".
-    1. If |well known response|'s [=response/body=] is not a JSON-encoded list of strings, return "continue".
+    1. If |well known response|'s [=response/status=] is not 200, return.
+    1. If |well known response|'s [=response/body=] is not a JSON-encoded list of strings, return.
     1. If |well known response|'s [=response/body=] does not include the origin of
-       |destination|, return "continue".
+       |destination|, return.
   1. If the input |session id| is present, delete the session with site
      |destination|'s site and identifier |session id|.
   1. Create a new session with:
@@ -476,7 +478,6 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
        specifications=] the value of the key "scope.scope_specification".
     1. [=session credentials=] the value of the key "credentials".
     1. [=session key=] a newly-generated key pair.
-  1. Return "restart".
 
 ## Create session ## {#algo-create-session}
 To <dfn export id="create-session">Create a new session</dfn> due to the
@@ -886,14 +887,19 @@ present:
 
 This specification requires an update to the <a
 href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">HTTP-network-or-cache
-fetch</a> algorithm. At the end of step 8.21, run
-[[#algo-identify-session-needing-refresh]]. If the resulting |session| is
-non-null, run [[#algo-session-request]] with the returned |session|'s [=session
-key=], [=refresh URL=], [=device bound session/session identifier=], [=cached
-challenge=], and an empty authorization. If the result is "restart", restart <a
-href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">HTTP-network-or-cache
-fetch</a> with the original inputs. Otherwise continue.
-
+fetch</a> algorithm. A [=request=] has a [=list=] of [=tuple=]s
+([=host/registrable domain=] |domain|, [=string=] |session id|), <dfn
+for="request">deferred device bound session ids</dfn>. This list is initially
+empty. At the end of step 8.21
+run [[#algo-identify-session-needing-refresh]]. If the resulting |session| is
+non-null:
+  1. Run [[#algo-session-request]] with the returned |session|'s
+    [=session key=], [=refresh URL=], [=device bound session/session
+    identifier=], [=cached challenge=], and an empty authorization.
+  2. Restart <a
+    href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">HTTP-network-or-cache
+    fetch</a> with the original inputs.
+    
 ## Changes to the Clear Site Data specification ## {#changes-to-clear-site-data}
 
 This specification requires that the Clear Site Data specification


### PR DESCRIPTION
In order to handle requests covered by multiple sessions, we shouldn't continue the request even after a failed refresh. Instead, we track the sessions that have already deferred the request, and refuse to defer due to the same session multiple times.