### PR TITLE
Rework type mismatches around origin vs URL vs host

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -318,8 +318,8 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   (|session identifier|), this algorithm returns a [=device bound session=] or
   null if no such session exists.
 
-  1. Let |site| be the [=host/registrable domain=] of |url|.
-  1. Let |domain sessions| be the user agent's [=session store=][|site|] as a
+  1. Let |domain| be the [=host/registrable domain=] of |url|'s [=url/host=].
+  1. Let |domain sessions| be the user agent's [=session store=][|domain|] as a
      [=/session by id=]
   1. Return |domain sessions|[|session identifier|]
 </div>
@@ -331,10 +331,10 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   "include" if |URL| is in scope, and "exclude" otherwise.
 
   1. Let |scope| be |session|'s [=session scope=].
-  1. If |scope| [=include site=] is true, return "exclude" if |URL| is
-     not [=/same site=] with |scope| [=session scope/origin=].
-  1. If |scope| [=include site=] is false, return "exclude" if |URL| is not
-     [=same origin=] with |scope| [=session scope/origin=].
+  1. If |scope|'s [=include site=] is true, return "exclude" if |URL|'s
+     [=/origin=] is not [=/same site=] with |scope|'s [=session scope/origin=].
+  1. If |scope|'s [=include site=] is false, return "exclude" if |URL|'s
+     [=/origin=] is not [=same origin=] with |scope|'s [=session scope/origin=].
   1. If the |URL| matches the |session|'s [=refresh URL=], return "exclude".
   1. [=list/for each=] |scope specification| in |scope|'s [=scope specifications=]:
     1. Let |host pattern| be |scope specification|'s [=scope 
@@ -396,14 +396,15 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   Given a [=request=] (|request|), this algorithm describes how to identify
   which session, if any, should block |request| from proceeding.
 
-  1. Let |site| be the [=host/registrable domain=] of the |request| [=URL=].
-  1. Let |domain sessions| be the user agent's [=session store=][|site|] as
+  1. Let |domain| be the [=host/registrable domain=] of the |request|'s
+     [=request/url=]'s [=url/host=].
+  1. Let |domain sessions| be the user agent's [=session store=][|domain|] as
      [=/session by id=]
   1. [=list/For each=] |session| of |domain sessions|
     1. If |session|'s [=expiration timestamp=] is before the present, remove
       |session| from |domain sessions| and [=iteration/continue=].
     1. Let |id| be |session|'s [=device bound session/session identifier=].
-    1. If the [=tuple=] (|site|, |id|) is in |request|'s
+    1. If the [=tuple=] (|domain|, |id|) is in |request|'s
       [=deferred device bound session ids=], [=iteration/continue=].
     1. Run the steps in [[#algo-url-in-scope]] on |request|'s [=request/URL=]
        and |session|.
@@ -415,7 +416,7 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
     1. If the result of running [[#algo-identify-missing-session-credential]]
       on |request| and |session|'s [=session credentials=] is false,
       [=iteration/continue=].
-    1. Add (|site|, |id|) to |request|'s [=deferred device bound session ids=].
+    1. Add (|domain|, |id|) to |request|'s [=deferred device bound session ids=].
     1. Return |session|.
   1. If no session has been identified, return null.
 </div>
@@ -487,11 +488,11 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
      to indicate this to the site.
   1. Let |terminate the session| be an algorithm with the following steps:
     1. If |session id| is null, return.
-    1. Remove the session with site |destination|'s [=host/registrable domain=]
-       and identifier |session id| from the user agent's [=session store=], if
-       such a session is found.
-  1. If |originating request|'s [=request/URL=] is not [=/same site=] with
-     |destination|, return.
+    1. Remove the session with domain |destination|'s [=url/host=]'s
+       [=host/registrable domain=] and identifier |session id| from the
+       user agent's [=session store=], if such a session if found.
+  1. If |originating request|'s [=request/URL=]'s [=/origin=] is not [=/same site=] with
+     |destination|'s [=/origin=], return.
   1. Let |signed challenge| be null. If |challenge| is non-null, sign it
      with |key pair| and store the result in |signed challenge|.
   1. Create a |request| for use in <a
@@ -546,20 +547,20 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
        "scope.origin", if present, or the origin of |destination| if
        not.
     1. |origin| must be a valid non-opaque origin.
-    1. |origin| must be same-site with |destination|.
+    1. |origin| must be [=/same site=] with |destination|'s [=/origin=].
     1. Let |refresh URL| be the result of resolving |destination| with the value
        of the key "refresh_url".
     1. |refresh URL| must have scheme HTTPS or be localhost.
-    1. |refresh URL| must be same-site with |destination|.
-  1. Let |destination site| be the [=host/registrable domain=] of |destination|.
+    1. |refresh URL|'s [=/origin=] must be [=/same site=] with |destination|'s [=/origin=].
+  1. Let |destination domain| be the [=host/registrable domain=] of |destination|'s [=url/host=].
   1. If the value of the key "scope.include_site" in |response| is true,
      perform the following validations. If any fail, |terminate the
      session| and return.
-    1. |origin|'s [=origin/domain=] must be equal to |destination site|.
-    1. If |destination site| is equal to the [=url/host=] of
-       |destination|, skip all remaining validations in this step.
+    1. |origin|'s [=origin/domain=] must be equal to |destination domain|.
+    1. If |destination domain| is equal to the [=url/host=] of
+        |destination|, skip all remaining validations.
     1. Otherwise, let |well known URL| be a copy of |destination|, with the
-       [=url/host=] replaced with |destination site|, and the [=url/path=]
+       [=url/host=] replaced with |destination domain|, and the [=url/path=]
        replaced with "/.well-known/device-bound-sessions".
     1. Let |well known response| be the result of fetching |well known URL|.
     1. |well known response|'s [=response/status=] must be 200.
@@ -582,7 +583,7 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
     1. [=allowed refresh initiators=] the value of the key "allowed_refresh_initiators".
   1. Call |terminate the session| to remove the existing session.
   1. Set the user agent's [=session store=][|destination
-     site|][|session identifier|] to |session|.
+     domain|][|session identifier|] to |session|.
 
 ## Create session ## {#algo-create-session}
 <div class="algorithm" data-algorithm="process-registration">


### PR DESCRIPTION
This fixes a few places we weren't precise about the types:
- Sites are not the same as registrable domains
- Registrable domains are extracted from hosts
- Origins are same-site, not URLs