### PR TITLE
Update redirect handling for DBSC requests

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -496,10 +496,10 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   1. Let |signed challenge| be null. If |challenge| is non-null, sign it
      with |key pair| and store the result in |signed challenge|.
   1. Create a |request| for use in <a
-     href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">HTTP-network-or-cache
-     fetch</a>.
+     href="https://fetch.spec.whatwg.org/#http-fetch">HTTP fetch</a>.
   1. Set |request|'s [=request/method=] to "POST".
   1. Set |request|'s [=request/URL=] to |destination|.
+  1. Set |request|'s [=request/redirect mode=] to "follow".
   1. If |signed challenge| is non-null, [=header list/append=] the header
      ("Secure-Session-Response", |signed challenge|) to |request|'s
      [=request/header list=].
@@ -508,13 +508,9 @@ The <dfn>session credential</dfn> is a [=struct=] with the following
   1. Set |request|'s [=request/initiator=] to |originating request|'s
      [=request/initiator=].
   1. Let |response| be the result of running <a
-     href="https://fetch.spec.whatwg.org/#http-network-or-cache-fetch">HTTP-network-or-cache
-     fetch</a> for |request|.
+     href="https://fetch.spec.whatwg.org/#http-fetch">HTTP fetch</a> for |request|.
   1. If |response| is a [=network error=], or |response|'s
      [=response/status=] is 407 or 429, return.
-  1. If |response|'s [=response/status=] is a [=redirect status=], and the
-     destination does not have an HTTPS scheme and is not localhost, cancel the
-     request and return.
   1. If |response|'s [=response/status=] is at least 300 and below 400, then
      return.
   1. If |response|'s [=response/status=] is 403:


### PR DESCRIPTION
The current description doesn't really align with the Fetch redirect handling. While it's nice to ensure that sites don't expose themselves to significant risk, we already require that the refresh URL be HTTPS, so sites need to do significant work to take on this risk. Simpler Fetch integration is valued over protecting sites from themselves.