### PR TITLE
Change some field defaults

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1103,11 +1103,13 @@ At the root of each [=JSON session scope rule=], the following keys can exist:
     
   : domain
   :: a [=string=] indicating the domains that should match the rule. This key
-    MUST be present. This can include wildcards (see [[#algo-url-in-scope]]).
+    is OPTIONAL; if not present, it will be '*', matching all domains. This can
+    include wildcards (see [[#algo-url-in-scope]]).
     
   : path
   :: a [=string=] indicating the path-prefixes that should match the rule. This
-    key MUST be present. See [[#algo-url-in-scope]] for the detailed semantics.
+    key is OPTIONAL; if not present, it will be '/', matching all paths. See
+    [[#algo-url-in-scope]] for the detailed semantics.
 
 ## JSON Session Credentials Format ## {#format-session-credentials}
 The server sends <dfn>JSON session credentials</dfn> in the [=JSON session

--- a/spec.bs
+++ b/spec.bs
@@ -1082,10 +1082,9 @@ At the root of the JSON object, the following keys can exist:
     
   : include_site
   :: a [=boolean=] indicating if the session is origin-scoped (false) or
-    site-scoped (true). This key is OPTIONAL; if not present, it will be false
-    (origin-scoped). Note that this takes precedence over any
-     [=JSON session scope rules=] in [=scope specification=] (see
-     [[#algo-url-in-scope]]).
+    site-scoped (true). This key is MANDATORY. Note that this takes precedence
+    over any [=JSON session scope rules=] in [=scope specification=] (see
+    [[#algo-url-in-scope]]).
     
   : scope_specification
   :: a [=list=] of [=JSON session scope rules=] describing modifications to the


### PR DESCRIPTION
Sites shouldn't have to specify both domain and path in every scope rule. By default, these should always match.

On the other hand, sites should have to specify include_site. A boolean value isn't too hard to declare, and this lets us make the field optional later with slightly different semantics (folding it into `session_inclusion_rules`)