### PR TITLE
Remove currently unused defer_requests field from the example

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1124,7 +1124,6 @@ At the root of the JSON object, the following keys can exist:
     "refresh_url": "/RefreshEndpoint",
 
     "continue": false,
-    "defer_requests": true, // optional and true by default
 
     "scope": {
       // Origin-scoped by default (i.e. https://example.com)


### PR DESCRIPTION
Since `defer_requests` is not defined anywhere in the spec, it seems to have been unintentionally left in the example.

Following https://github.com/w3c/webappsec-dbsc/pull/121, the `defer_requests` field has been deleted.