### PR TITLE
[Editorial] Shift Kristian Monsen to emeritus status.

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -6,9 +6,9 @@ Indent: 2
 Status: ED
 Group: webappsec
 ED: https://w3c.github.io/webappsec-dbsc/
-Editor: Kristian Monsen 76841, Google, kristianm@google.com
 Editor: Daniel Rubery 162789, Google, drubery@google.com
 Editor: thefrog@chromium.org 164860, Google, thefrog@chromium.org
+Former Editor: Kristian Monsen 76841, Apple
 Abstract: Device Bound Sessions Credentials (DBSC) aims to prevent hijacking via cookie theft by building a protocol and infrastructure that allows a user agent to assert possession of a securely-stored private key. DBSC is a Web API and a protocol between user agents and servers to achieve this binding.
 Repository: https://github.com/w3c/webappsec-dbsc/
 Markup Shorthands: css no, markdown yes


### PR DESCRIPTION
My understanding is that @kmonsen is no longer actively contributing to this specification, and that the affiliation with Google is outdated. Is this an accurate adjustment, @kmonsen, @drubery, and @thefrog-gh?