### PR TITLE
Fix example of `Secure-Session-Skipped`

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -1073,7 +1073,7 @@ One <a>sf-parameter</a> is defined:
 <div class="example" id="secure-session-skipped-example">
   ```html
   GET example.com/requires_bound_cookie
-  Secure-Session-Skipped: unreachable;session_identifier=123, quota_exceeded;session_identifier=456
+  Secure-Session-Skipped: unreachable;session_identifier="123", quota_exceeded;session_identifier="456"
   ```
 </div>
 


### PR DESCRIPTION
Hey! We are implementing DBSC, and noticed that the example of `Secure-Session-Skipped` header is missing double quotes (`"`) around `session_identifier` parameters' values. Having double quotes there would be consistent with the spec's wording that value if supposed to be an `sf-string` as well as the actual headers we are observing:
> An [sf-parameter](https://datatracker.ietf.org/doc/html/rfc9651#name-parameters) whose key is "session_identifier", and whose value is an [sf-string](https://datatracker.ietf.org/doc/html/rfc9651#string), conveying the identifier of the skipped session.