### PR TITLE
Re-run challenge header processing after creating a session

### DIFF
--- a/spec.bs
+++ b/spec.bs
@@ -766,6 +766,7 @@ steps:
     1. Set the user agent's [=session store=][|destination
        domain|][|session identifier|] to |session|.
     1. [=iteration/Break=].
+  1. Run [[#algo-process-challenge]] on |response|.
 </div>
 
 ## Process session registration ## {#algo-process-session-registration}


### PR DESCRIPTION
To relieve site developers from having to understand the nuances of DBSC's fetch integration, we want to allow the registration response to do both registration and set a challenge.

This change is needed because normally, the challenge header is processed before registration, and at that point there is no session to cache the requested challenge onto.