### PR TITLE
Update language around Max-Age in credential attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,8 @@ Set-Cookie: auth_cookie=abcdef0123; Domain=example.com; Max-Age=600; Secure; Htt
     // response.
     "name": "auth_cookie",
     "attributes": "Domain=example.com; Path=/; Secure; HttpOnly; SameSite=None"
-    // Attributes Max-Age and Expires are ignored
+    // Attributes Max-Age and Expires will not contribute to whether a request
+	// cookie satisfies this credential.
   }]
 }
 ```

--- a/spec.bs
+++ b/spec.bs
@@ -1157,12 +1157,10 @@ At the root of the JSON object, the following keys can exist:
       // This specifies the exact cookie that this config applies to. Attributes
       // match the cookie attributes in RFC 6265bis and are parsed similarly to
       // a normal Set-Cookie line, using the same default values.
-      // These SHOULD be equivalent to the Set-Cookie line accompanying this 
-      // response.
       "name": "auth_cookie",
       "attributes": "Domain=example.com; Path=/; Secure; HttpOnly; SameSite=None"
       // Attributes Max-Age and Expires will not contribute to whether a request
-      // cookie satisfies this credential
+      // cookie satisfies this credential.
     }],
     
     "allowed_refresh_initiators": [


### PR DESCRIPTION
We say "Attributes Max-Age and Expires are ignored", but we don't mean that they must be ignored if presetn, just that they don't matter when matching request cookies to config credentials. In fact, Chrome rejects sessions with these attributes to keep developers from believing they are semantically meaningful.

This will address https://github.com/w3c/webappsec-dbsc/issues/230